### PR TITLE
Do not install rustup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ e2e-test: build-image
 runtime-samples:
 	cd runtime-samples && make
 
+rust-unit-tests:
+	cd extractor && make unit-tests
+
 unit-tests:
 	cd fingerprints && make unit-tests
 	cd exporter && make unit-tests
-	cd extractor && make unit-tests

--- a/extractor/Makefile
+++ b/extractor/Makefile
@@ -11,14 +11,11 @@ else
 	cargo build --release --target x86_64-unknown-linux-musl
 endif
 
-setup:
-	curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.81.0 -y
-
 clean:
 	cargo clean
 
 unit-tests: build
 	cargo test
 
-check: setup
+check:
 	cargo fmt -- --check


### PR DESCRIPTION
when running the rust unit tests as it is provided by the container image running the tests