### PR TITLE
generate tests junit xml report

### DIFF
--- a/exporter/Makefile
+++ b/exporter/Makefile
@@ -22,7 +22,8 @@ e2e-setup: install-helm
 	export TEST_NAMESPACE=${TEST_NAMESPACE} && cd test/e2e && ./setup.sh
 
 e2e-test: e2e-setup
-	export TEST_NAMESPACE=${TEST_NAMESPACE} && go test -p 1 -timeout 1h -count=1 -v ./test/e2e/...
+	export TEST_NAMESPACE=${TEST_NAMESPACE} && go test -p 1 -timeout 1h -count=1 -v 2>&1 ./test/e2e/... | tee test-results.raw
+	cat test-results.raw | go-junit-report -set-exit-code > test-results-junit.xml
 
 clean-e2e:
 	oc delete namespace ${TEST_NAMESPACE}


### PR DESCRIPTION
Test results in standard output and generate junit report xml file. This is very useful for jenkins job test automation.
You need to first install [go-junit-reporter](https://github.com/jstemmer/go-junit-report) 
go install github.com/jstemmer/go-junit-report/v2@latest
