### PR TITLE
[e2e] add test for Red Hat Build of Quarkus

### DIFF
--- a/exporter/test/e2e/quarkus_test.go
+++ b/exporter/test/e2e/quarkus_test.go
@@ -110,3 +110,30 @@ func TestNativeQuarkus_3_15_1(t *testing.T) {
 		}))
 	_ = testenv.Test(t, feature.Feature())
 }
+
+func TestRedHatBuildOfQuarkus_3_8_6(t *testing.T) {
+
+	appName := "quarkus"
+	containerName := "main"
+	image := "quay.io/insights-runtime-extractor-samples/rhbq-app:1.0.0"
+	deployment := newAppDeployment(namespace, appName, 1, containerName, image)
+
+	feature := features.New("Red Hat Build of Quarkus from "+image).
+		Setup(deployTestResource(deployment, appName)).
+		Teardown(undeployTestResource(deployment, appName)).
+		Assess("runtime info extracted", checkExtractedRuntimeInfo(namespace, "app="+appName, containerName, func(g *Ω.WithT, runtimeInfo types.ContainerRuntimeInfo) {
+			expected := types.ContainerRuntimeInfo{
+				Os:              "rhel",
+				OsVersion:       "8.10",
+				Kind:            "Java",
+				KindVersion:     "17.0.13",
+				KindImplementer: "Red Hat, Inc.",
+				Runtimes: []types.RuntimeComponent{{
+					Name:    "Quarkus",
+					Version: "3.8.6.redhat-00004",
+				}},
+			}
+			g.Expect(runtimeInfo).Should(Ω.Equal(expected))
+		}))
+	_ = testenv.Test(t, feature.Feature())
+}

--- a/extractor/src/insights_runtime_extractor/fingerprint/java.rs
+++ b/extractor/src/insights_runtime_extractor/fingerprint/java.rs
@@ -44,7 +44,7 @@ impl Java {
     ) -> Option<Vec<String>> {
         let jar = match jar {
             jar if jar.starts_with("/") => jar.to_owned(),
-            jar => format!("{:?}/{}", process.cwd, jar),
+            jar => format!("{}/{}", process.cwd.as_deref().unwrap(), jar),
         };
 
         return Some(vec![

--- a/runtime-samples/Makefile
+++ b/runtime-samples/Makefile
@@ -1,6 +1,6 @@
-.PHONY: golang-app quarkus-3.13.0 quarkus-3.15.1 spring-boot
+.PHONY: golang-app quarkus-3.13.0 quarkus-3.15.1 spring-boot RHBQ
 
-all: quarkus-3.13.0 quarkus-3.15.1 spring-boot golang-app
+all: quarkus-3.13.0 quarkus-3.15.1 spring-boot golang-app RHBQ
 
 golang-app:
 	cd ./golang-app && make
@@ -13,3 +13,6 @@ quarkus-3.15.1:
 
 spring-boot:
 	cd ./spring-boot && make
+
+RHBQ:
+	cd ./RHBQ && make

--- a/runtime-samples/RHBQ/Containerfile
+++ b/runtime-samples/RHBQ/Containerfile
@@ -1,6 +1,6 @@
 # corresponded to Red Hat OpenJDK 17 UBI8
 FROM registry.access.redhat.com/ubi8/openjdk-17@sha256:7d7c73b9fa4ae18fd5a976b84e0e230ca7907419caff507b5a25e4a04a83a8ce
-ARG QUARKUS_APP_DIR=target/quarkus-app/*.*
-COPY ${QUARKUS_APP_DIR} quarkus-app
-ENTRYPOINT ["java","-jar","/quarkus-run.jar"]
+ARG QUARKUS_APP_DIR=target/quarkus-app/
+COPY ${QUARKUS_APP_DIR} /quarkus-app
 WORKDIR /quarkus-app
+ENTRYPOINT ["java","-jar","quarkus-run.jar"]

--- a/runtime-samples/RHBQ/Containerfile
+++ b/runtime-samples/RHBQ/Containerfile
@@ -1,0 +1,6 @@
+# corresponded to Red Hat OpenJDK 17 UBI8
+FROM registry.access.redhat.com/ubi8/openjdk-17@sha256:7d7c73b9fa4ae18fd5a976b84e0e230ca7907419caff507b5a25e4a04a83a8ce
+ARG QUARKUS_APP_DIR=target/quarkus-app/*.*
+COPY ${QUARKUS_APP_DIR} quarkus-app
+ENTRYPOINT ["java","-jar","/quarkus-run.jar"]
+WORKDIR /quarkus-app

--- a/runtime-samples/RHBQ/Makefile
+++ b/runtime-samples/RHBQ/Makefile
@@ -1,0 +1,7 @@
+.DEFAULT_GOAL = push
+
+build:
+	mvn install
+
+push: build
+	./deploy.sh

--- a/runtime-samples/RHBQ/README.md
+++ b/runtime-samples/RHBQ/README.md
@@ -14,5 +14,17 @@ make
 For the OpenJDK image:
 
 ```json
-xxxx
+"runtimeInfo": {
+  "os": "rhel",
+  "osVersion": "8.10",
+  "kind": "Java",
+  "kindVersion": "17.0.13",
+  "kindImplementer": "Red Hat, Inc.",
+  "runtimes": [ 
+    {
+      "name": "Quarkus",
+      "version": "3.8.6.redhat-00004"
+    }
+  ]
+}
 ```

--- a/runtime-samples/RHBQ/README.md
+++ b/runtime-samples/RHBQ/README.md
@@ -1,0 +1,30 @@
+# Red Hat build of Quarkus 3.8.6.redhat-00005
+
+# Runtime sample for the insights-runtime-extractor
+
+To build the container image and make it available to the OpenShift internal image
+registry, run:
+
+```shell script
+make
+```
+
+# Workload Runtime Information:
+
+For the OpenJDK image:
+
+```json
+"runtimeInfo": {
+  "os": "rhel",
+  "osVersion": "8.10",
+  "kind": "Java",
+  "kindVersion": "21.0.4",
+  "kindImplementer": "Red Hat, Inc.",
+  "runtimes": [ 
+    {
+      "name": "Quarkus",
+      "version": "3.15.1"
+    }
+  ]
+}
+```

--- a/runtime-samples/RHBQ/README.md
+++ b/runtime-samples/RHBQ/README.md
@@ -14,17 +14,5 @@ make
 For the OpenJDK image:
 
 ```json
-"runtimeInfo": {
-  "os": "rhel",
-  "osVersion": "8.10",
-  "kind": "Java",
-  "kindVersion": "21.0.4",
-  "kindImplementer": "Red Hat, Inc.",
-  "runtimes": [ 
-    {
-      "name": "Quarkus",
-      "version": "3.15.1"
-    }
-  ]
-}
+xxxx
 ```

--- a/runtime-samples/RHBQ/deploy.sh
+++ b/runtime-samples/RHBQ/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+IMAGE=quay.io/insights-runtime-extractor-samples/rhbq-app:1.0.0
+
+echo "Building & pushing ${IMAGE}"
+podman build --platform linux/amd64 -t ${IMAGE} .
+podman push ${IMAGE}

--- a/runtime-samples/RHBQ/pom.xml
+++ b/runtime-samples/RHBQ/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.redhat.insights</groupId>
+    <version>1.0.0</version>
+    <artifactId>rhbq-app</artifactId>
+    <packaging>jar</packaging>
+    <name>Insights test app for RedHatBuildOfQuarkus</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <quarkus.platform.version>3.8.6.redhat-00005</quarkus.platform.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.redhat.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>com.redhat.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/runtime-samples/RHBQ/pom.xml
+++ b/runtime-samples/RHBQ/pom.xml
@@ -54,4 +54,17 @@
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>redhat-mrrc</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <repositories>
+        <repository>
+            <id>redhat-mrrc</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+        </repository>
+    </repositories>
 </project>

--- a/runtime-samples/RHBQ/src/main/java/io/quarkus/ts/http/minimum/Hello.java
+++ b/runtime-samples/RHBQ/src/main/java/io/quarkus/ts/http/minimum/Hello.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.http.minimum;
+
+public class Hello {
+
+    private final String content;
+
+    public Hello(String content) {
+        this.content = content;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/runtime-samples/RHBQ/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
+++ b/runtime-samples/RHBQ/src/main/java/io/quarkus/ts/http/minimum/HelloResource.java
@@ -1,0 +1,42 @@
+package io.quarkus.ts.http.minimum;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/hello")
+public class HelloResource {
+    private static final String TEMPLATE = "Hello, %s!";
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Hello get(@QueryParam("name") @DefaultValue("World") String name) {
+        return new Hello(String.format(TEMPLATE, name));
+    }
+
+    @GET
+    @Path("/json")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Hello getJson() {
+        return new Hello("hello");
+    }
+
+    @GET
+    @Path("/foo/{something-with-dash:[A-Z0-9]{4}}")
+    public Response doSomething(@PathParam("something-with-dash") String param) {
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/no-content-length")
+    public Response hello() {
+        return Response.ok("hello").header("Transfer-Encoding", "chunked").build();
+    }
+}

--- a/runtime-samples/RHBQ/src/main/resources/application.properties
+++ b/runtime-samples/RHBQ/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.application.name=test-http
+quarkus.http.root-path=/api
+# Only run tests annotated with @QuarkusTest
+%DevModeHttpMinimumIT.quarkus.test.type=quarkus-test
+# Test Framework expects the dev UI to be at /q/dev, not /api/q/dev
+%DevModeHttpMinimumIT.quarkus.http.root-path=/


### PR DESCRIPTION
@liborfuka This supersedes #26 

The runtime-sample image is published at https://quay.io/repository/insights-runtime-extractor-samples/rhbq-app?tab=info

Please note that the extracted Quarkus version is `3.8.6.redhat-00004` as we report the version of `io.quarkus:quarkus-core`.
So in this sample, although we are using `quarkus-bom 3.8.6.redhat-00005`, the reported version is `Quarkus 3.8.6.redhat-00004`