### PR TITLE
[e2e] store all tested images in quay.io

### DIFF
--- a/exporter/test/e2e/nodejs_test.go
+++ b/exporter/test/e2e/nodejs_test.go
@@ -13,7 +13,7 @@ func TestNodeJS(t *testing.T) {
 	appName := "node-app"
 	containerName := "nodejs"
 	// corresponded to node:22.6.0-alpine3.20
-	image := "node@sha256:4162c8a0f1fef9d3b003eb1fd3d8a26db46815288832aa453d829f4129d4dfd3"
+	image := "quay.io/insights-runtime-extractor-samples/node@sha256:4162c8a0f1fef9d3b003eb1fd3d8a26db46815288832aa453d829f4129d4dfd3"
 	deployment := newNodeAppDeployment(namespace, appName, 1, containerName, image)
 
 	feature := features.New("Node.js from base image "+image).

--- a/exporter/test/e2e/os_test.go
+++ b/exporter/test/e2e/os_test.go
@@ -20,11 +20,11 @@ func TestUbi8Minimal(t *testing.T) {
 }
 
 func TestDebian(t *testing.T) {
-	testBaseImage(t, "debian:12", "debian", "12")
+	testBaseImage(t, "quay.io/insights-runtime-extractor-samples/debian:12", "debian", "12")
 }
 
 func TestCentOs7(t *testing.T) {
-	testBaseImage(t, "centos:7", "centos", "7")
+	testBaseImage(t, "quay.io/insights-runtime-extractor-samples/centos:7", "centos", "7")
 }
 
 func testBaseImage(t *testing.T, baseImage string, expectedOs string, expectedOsVersion string) {

--- a/exporter/test/e2e/python_test.go
+++ b/exporter/test/e2e/python_test.go
@@ -14,7 +14,7 @@ func TestPython3(t *testing.T) {
 	appName := "python3-app"
 	containerName := "python"
 	// corresponded to python:3.9.19-slim
-	image := "python@sha256:85c7a2a383a01e0b77b5f9c97d8b1eef70409a99552fde03c518a98dfa19609c"
+	image := "quay.io/insights-runtime-extractor-samples/python@sha256:69e712dbe4c4a166527cbf69374533125cfb6ee93a5e39031a0191c741d386d7"
 	deployment := newPython3AppDeployment(namespace, appName, 1, containerName, image)
 
 	feature := features.New("Python3 from base image "+image).

--- a/exporter/test/e2e/tomcat_test.go
+++ b/exporter/test/e2e/tomcat_test.go
@@ -12,8 +12,8 @@ func TestTomcat(t *testing.T) {
 
 	appName := "tomcat"
 	containerName := "main"
-	// Tomcat image that corresponded to 11.0-jre21
-	image := "tomcat@sha256:3b353d4a30c315ae1177b04642c932e07fcd87155452629d4809c38d9854de72"
+	// Tomcat image that corresponded to tomcat:11.0-jre21
+	image := "quay.io/insights-runtime-extractor-samples/tomcat@sha256:505c9fcae748e2e0488c8aa13794f041088b4771739aa906ef761b124474c874"
 	deployment := newAppDeployment(namespace, appName, 1, containerName, image)
 
 	feature := features.New("Tomcat from base image "+image).
@@ -24,11 +24,11 @@ func TestTomcat(t *testing.T) {
 				Os:              "ubuntu",
 				OsVersion:       "24.04",
 				Kind:            "Java",
-				KindVersion:     "21.0.4",
+				KindVersion:     "21.0.5",
 				KindImplementer: "Eclipse Adoptium",
 				Runtimes: []types.RuntimeComponent{{
 					Name:    "Apache Tomcat",
-					Version: "11.0.0-M22",
+					Version: "11.0.1",
 				}},
 			}
 			g.Expect(runtimeInfo).Should(Ω.Equal(expected))


### PR DESCRIPTION
Pull all images from quay.io/insights-runtime-samples. Images that were pulled from hub.docker.com were copied using skopeo