### PR TITLE
[e2e] Delete the extractor namespace before running the test suite

### DIFF
--- a/exporter/test/e2e/helper.go
+++ b/exporter/test/e2e/helper.go
@@ -8,12 +8,11 @@ import (
 	"testing"
 	"time"
 
-	apimachinerywait "k8s.io/apimachinery/pkg/util/wait"
-
 	Ω "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerywait "k8s.io/apimachinery/pkg/util/wait"
 
 	"sigs.k8s.io/e2e-framework/klient"
 	"sigs.k8s.io/e2e-framework/klient/k8s"

--- a/exporter/test/e2e/main_test.go
+++ b/exporter/test/e2e/main_test.go
@@ -34,8 +34,8 @@ func TestMain(m *testing.M) {
 	testenv = env.NewWithConfig(cfg)
 	namespace = "e2e-insights-runtime-extractor"
 	insightsRuntimeExtractorNamespace = os.Getenv("TEST_NAMESPACE")
-	testedExtractorImage := "insights-runtime-extractor:latest"
-	testedExporterImage := "insights-runtime-exporter:latest"
+	testedExtractorImage := "quay.io/openshift/origin-insights-runtime-extractor:latest"
+	testedExporterImage := "quay.io/openshift/origin-insights-runtime-exporter:latest"
 	if imageRegistry, ok := os.LookupEnv("IMAGE_REGISTRY"); ok {
 		testedExtractorImage = imageRegistry + "/insights-runtime-extractor:latest"
 		testedExporterImage = imageRegistry + "/insights-runtime-exporter:latest"

--- a/exporter/test/e2e/setup.sh
+++ b/exporter/test/e2e/setup.sh
@@ -1,6 +1,13 @@
 go install  -mod=readonly  github.com/jstemmer/go-junit-report/v2@latest
 
+oc delete project $TEST_NAMESPACE
+kubectl wait --for=delete namespace/$TEST_NAMESPACE --timeout=60s
+
+oc delete project e2e-insights-runtime-extractor
+kubectl wait --for=delete namespace/e2e-insights-runtime-extractor --timeout=60s
+
 echo Using namespace for the insights-runtime-extractor: $TEST_NAMESPACE
 
 oc new-project $TEST_NAMESPACE
 oc apply -f test/e2e/insights-runtime-extractor-scc.yaml -n $TEST_NAMESPACE
+


### PR DESCRIPTION
It ensures that the job starts with a clean namespace for every run.