### PR TITLE
Fix JBoss EAP detection

### DIFF
--- a/fingerprints/cmd/fpr_java_jboss_modules/main.go
+++ b/fingerprints/cmd/fpr_java_jboss_modules/main.go
@@ -14,7 +14,7 @@ const (
 	versionDelimiter                    = "- Version"
 	productManifestPath                 = "modules/system/layers/base/org/jboss/as/product/main/dir/META-INF/MANIFEST.MF"
 	productMainPath                     = "modules/system/layers/base/org/jboss/as/product/main/"
-	wildflyFeaturePackProductConfPrefix = "wildfly-feature-pack-product-conf"
+	wildflyFeaturePackProductConfPrefix = "wildfly-ee-feature-pack-product-conf"
 	jbossProductReleaseName             = "JBoss-Product-Release-Name"
 	jbossProductReleaseVersion          = "JBoss-Product-Release-Version"
 )


### PR DESCRIPTION
The jar that contains JBoss Product Release Version for EAP 8.0 is named wildfly-ee-feature-pack-product-conf (and published in MRRC at https://maven.repository.redhat.com/ga/org/jboss/eap/wildfly-ee-feature-pack-product-conf/).