### PR TITLE
NO-JIRA: Add new owners required for managing OCP CI config

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,12 @@
 approvers:
 - jmesnil
+- ncaak
+- opokornyy
+- IshwarKanse
 reviewers:
 - jmesnil
+- ncaak
+- opokornyy
+- IshwarKanse
 
 component: "Insights Runtime Extractor"


### PR DESCRIPTION
The PR adds new owners to manage OCP CI config. 
https://github.com/openshift/release/pull/82056

