### PR TITLE
CCXDEV-16674: chore: add clippy linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ rust-unit-tests:
 unit-tests:
 	cd fingerprints && make unit-tests
 	cd exporter && make unit-tests
+
+lint:
+	cd extractor && make check

--- a/extractor/Makefile
+++ b/extractor/Makefile
@@ -9,4 +9,13 @@ unit-tests: build
 	cargo test
 
 check:
+	@result=0; \
+	$(MAKE) fmt-check || result=1; \
+	$(MAKE) clippy || result=1; \
+	exit $$result
+
+fmt-check:
 	cargo fmt -- --check
+
+clippy:
+	cargo clippy -- -D warnings


### PR DESCRIPTION
Add clippy linting support for Rust extractor

We can add linting to ci job if changes are ok.

cc: @jmesnil 


From the local run:

```bash
╭─░▒▓ ~/gi/s/insights-runtime-extractor  feat/add-clippy-linting
╰─ make rust-dev                                                                                    ─╯
./scripts/rust-dev.sh
[root@94937286f238 extractor]# make check
make[1]: Entering directory '/opt/app-root/src/insights-runtime-extractor/extractor'
cargo fmt -- --check
Diff in /opt/app-root/src/insights-runtime-extractor/extractor/src/bin/extractor_server.rs:25:
 
     let log_level = args.log_level.unwrap_or(String::from("info"));

-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level.clone())).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level.clone()))
+        .init();
 
     info!("Gather runtime information from containers on OpenShift");

Diff in /opt/app-root/src/insights-runtime-extractor/extractor/src/insights_runtime_extractor/fingerprint/java.rs:24:
                 &process.pid, jboss_home_dir
             );
 
-            return  Some(vec![
-                    String::from("./fpr_java_jboss_modules"),
-                    out_dir.to_string(),
-                    jboss_home_dir,
-                ])
+            return Some(vec![
+                String::from("./fpr_java_jboss_modules"),
+                out_dir.to_string(),
+                jboss_home_dir,
+            ]);
         }
 
         return process
Diff in /opt/app-root/src/insights-runtime-extractor/extractor/src/insights_runtime_extractor/fingerprint/native_executable.rs:18:
     ) -> Option<Vec<String>> {
         debug!("Checking if {} is a native executable", &process.name);
 
-        let version_exec = VersionExecutable {
-        };
+        let version_exec = VersionExecutable {};
 
         // do not check for native executables if they have a `--version` way
         // to get their versions
Diff in /opt/app-root/src/insights-runtime-extractor/extractor/src/insights_runtime_extractor/process.rs:22:
     let leaves = get_leaves(&pid);
     debug!("got leaves: {:#?}", leaves);
 
-    let res: Vec<ContainerProcess>= leaves
+    let res: Vec<ContainerProcess> = leaves
         .iter()
         .map(|pid| s.process(Pid::from_u32(*pid)))
         .flatten()
make[1]: *** [Makefile:18: fmt-check] Error 1
make[1]: Leaving directory '/opt/app-root/src/insights-runtime-extractor/extractor'
make[1]: Entering directory '/opt/app-root/src/insights-runtime-extractor/extractor'
cargo clippy -- -D warnings
    Checking insights-runtime-extractor v0.1.0 (/opt/app-root/src/insights-runtime-extractor/extractor)
error: unneeded `return` statement
  --> src/insights_runtime_extractor/container.rs:76:5
   |
76 |     return containers;
   |     ^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_return
   = note: `-D clippy::needless-return` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_return)]`
help: remove `return`
   |
76 -     return containers;
76 +     containers
   |

error: unneeded `return` statement
  --> src/insights_runtime_extractor/container.rs:97:5
   |
97 |     return pid;
   |     ^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_return
help: remove `return`
   |
97 -     return pid;
97 +     pid
   |

error: writing `&String` instead of `&str` involves a new object where a slice will do
  --> src/insights_runtime_extractor/container.rs:79:35
   |
79 | pub fn get_root_pid(container_id: &String) -> u32 {
   |                                   ^^^^^^^ help: change this to: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#ptr_arg
   = note: `-D clippy::ptr-arg` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::ptr_arg)]`

error: the borrowed expression implements the required traits
  --> src/insights_runtime_extractor/file.rs:15:40
   |
15 |     if let Err(e) = fs::remove_dir_all(&name) {
   |                                        ^^^^^ help: change this to: `name`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrows_for_generic_args
   = note: `-D clippy::needless-borrows-for-generic-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_borrows_for_generic_args)]`

error: the borrowed expression implements the required traits
  --> src/insights_runtime_extractor/file.rs:21:25
   |
21 |     fs::set_permissions(&name, fs::Permissions::from_mode(0o777))?;
   |                         ^^^^^ help: change this to: `name`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrows_for_generic_args

error: the borrowed expression implements the required traits
  --> src/insights_runtime_extractor/file.rs:23:16
   |
23 |     File::open(&name)
   |                ^^^^^ help: change this to: `name`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrows_for_generic_args

error: length comparison to zero
  --> src/insights_runtime_extractor/file.rs:53:8
   |
53 |     if entries.len() == 0 {
   |        ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `entries.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#len_zero
   = note: `-D clippy::len-zero` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::len_zero)]`

error: unneeded `return` statement
  --> src/insights_runtime_extractor/fingerprint/java.rs:34:9
   |
34 | /         return process
35 | |             .command_line
36 | |             .iter()
37 | |             .position(|s| s.starts_with("-Djboss.home.dir"))
...  |
50 | |                 ])
51 | |             });
   | |______________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_return
help: remove `return`
   |
34 ~         process
35 +             .command_line
36 +             .iter()
37 +             .position(|s| s.starts_with("-Djboss.home.dir"))
38 +             .and_then(|i| process.command_line.get(i))
39 +             .and_then(|jboss_home_dir_sys_prop| jboss_home_dir_sys_prop.split_once("="))
40 +             .and_then(|(_, jboss_home_dir)| {
41 +                 debug!(
42 +                     "Process {} is using JBoss Module from JBoss Home {:#?}",
43 +                     &process.pid, jboss_home_dir
44 +                 );
45 + 
46 +                 Some(vec![
47 +                     String::from("./fpr_java_jboss_modules"),
48 +                     out_dir.to_string(),
49 +                     jboss_home_dir.to_string(),
50 +                 ])
51 ~             })
   |

error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
  --> src/insights_runtime_extractor/fingerprint/java.rs:34:16
   |
34 |           return process
   |  ________________^
35 | |             .command_line
36 | |             .iter()
37 | |             .position(|s| s.starts_with("-Djboss.home.dir"))
...  |
50 | |                 ])
51 | |             });
   | |______________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#bind_instead_of_map
   = note: `-D clippy::bind-instead-of-map` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::bind_instead_of_map)]`
help: use `map` instead
   |
40 ~             .map(|(_, jboss_home_dir)| {
41 |                 debug!(
...
45 |
46 ~                 vec![
47 +                     String::from("./fpr_java_jboss_modules"),
48 +                     out_dir.to_string(),
49 +                     jboss_home_dir.to_string(),
50 +                 ]
   |

error: unneeded `return` statement
  --> src/insights_runtime_extractor/fingerprint/java.rs:64:9
   |
64 | /         return Some(vec![
65 | |             String::from("./fpr_java_runtimes"),
66 | |             out_dir.to_string(),
67 | |             jar.to_string(),
68 | |         ]);
   | |__________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_return
help: remove `return`
   |
64 ~         Some(vec![
65 +             String::from("./fpr_java_runtimes"),
66 +             out_dir.to_string(),
67 +             jar.to_string(),
68 ~         ])
   |

error: unneeded `return` statement
  --> src/insights_runtime_extractor/fingerprint/java.rs:94:21
   |
94 |                     return Java::jboss_modules_executable(&out_dir, process);
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_return
help: remove `return`
   |
94 -                     return Java::jboss_modules_executable(&out_dir, process);
94 +                     Java::jboss_modules_executable(&out_dir, process)
   |

error: unneeded `return` statement
  --> src/insights_runtime_extractor/fingerprint/java.rs:96:21
   |
96 |                     return Java::jar_executable(&out_dir, process, jar);
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_return
help: remove `return`
   |
96 -                     return Java::jar_executable(&out_dir, process, jar);
96 +                     Java::jar_executable(&out_dir, process, jar)
   |

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/fingerprint/java.rs:94:59
   |
94 |                     return Java::jboss_modules_executable(&out_dir, process);
   |                                                           ^^^^^^^^ help: change this to: `out_dir`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow
   = note: `-D clippy::needless-borrow` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_borrow)]`

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/fingerprint/java.rs:96:49
   |
96 |                     return Java::jar_executable(&out_dir, process, jar);
   |                                                 ^^^^^^^^ help: change this to: `out_dir`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: unneeded `return` statement
   --> src/insights_runtime_extractor/fingerprint/java.rs:126:45
    |
126 | ...                   .and_then(|jar| return Java::jar_executable(&out_dir, process, &jar));
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_return
help: remove `return`
    |
126 -                             .and_then(|jar| return Java::jar_executable(&out_dir, process, &jar));
126 +                             .and_then(|jar| Java::jar_executable(&out_dir, process, &jar));
    |

error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/insights_runtime_extractor/fingerprint/java.rs:126:73
    |
126 | ...                   .and_then(|jar| return Java::jar_executable(&out_dir, process, &jar));
    |                                                                   ^^^^^^^^ help: change this to: `out_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/insights_runtime_extractor/fingerprint/java.rs:126:92
    |
126 | ...                   .and_then(|jar| return Java::jar_executable(&out_dir, process, &jar));
    |                                                                                      ^^^^ help: change this to: `jar`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: useless conversion to the same type: `std::option::Option<std::vec::Vec<std::string::String>>`
   --> src/insights_runtime_extractor/fingerprint/java.rs:128:36
    |
128 | ...                   return found.into();
    |                              ^^^^^^^^^^^^ help: consider removing `.into()`: `found`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#useless_conversion
    = note: `-D clippy::useless-conversion` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/fingerprint/native_executable.rs:26:41
   |
26 |         match version_exec.can_apply_to(&config, &out_dir, &process) {
   |                                         ^^^^^^^ help: change this to: `config`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/fingerprint/native_executable.rs:26:50
   |
26 |         match version_exec.can_apply_to(&config, &out_dir, &process) {
   |                                                  ^^^^^^^^ help: change this to: `out_dir`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/fingerprint/native_executable.rs:26:60
   |
26 |         match version_exec.can_apply_to(&config, &out_dir, &process) {
   |                                                            ^^^^^^^^ help: change this to: `process`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: accessing first element with `process.command_line.get(0)`
  --> src/insights_runtime_extractor/fingerprint/native_executable.rs:32:17
   |
32 |                 process.command_line.get(0)?.clone(),
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `process.command_line.first()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#get_first
   = note: `-D clippy::get-first` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::get_first)]`

error: writing `&String` instead of `&str` involves a new object where a slice will do
  --> src/insights_runtime_extractor/fingerprint.rs:16:18
   |
16 |         out_dir: &String,
   |                  ^^^^^^^ help: change this to: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#ptr_arg

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/fingerprint.rs:34:62
   |
34 |         if let Some(exec) = fingerprint.can_apply_to(config, &out_dir, &process) {
   |                                                              ^^^^^^^^ help: change this to: `out_dir`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/fingerprint.rs:34:72
   |
34 |         if let Some(exec) = fingerprint.can_apply_to(config, &out_dir, &process) {
   |                                                                        ^^^^^^^^ help: change this to: `process`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: the borrowed expression implements the required traits
  --> src/insights_runtime_extractor/fingerprint.rs:37:44
   |
37 |                 let command = Command::new(&command).args(args).output();
   |                                            ^^^^^^^^ help: change this to: `command`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrows_for_generic_args

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/process.rs:22:29
   |
22 |     let leaves = get_leaves(&pid);
   |                             ^^^^ help: change this to: `pid`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: called `map(..).flatten()` on `Iterator`
  --> src/insights_runtime_extractor/process.rs:27:10
   |
27 |           .map(|pid| s.process(Pid::from_u32(*pid)))
   |  __________^
28 | |         .flatten()
   | |__________________^ help: try replacing `map` with `filter_map` and remove the `.flatten()`: `filter_map(|pid| s.process(Pid::from_u32(*pid)))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#map_flatten
   = note: `-D clippy::map-flatten` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::map_flatten)]`

error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
  --> src/insights_runtime_extractor/process.rs:34:18
   |
34 |               cwd: process
   |  __________________^
35 | |                 .cwd()
36 | |                 .and_then(|p| Some(p.to_string_lossy().into_owned())),
   | |_____________________________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#bind_instead_of_map
help: try
   |
34 ~             cwd: process
35 ~                 .cwd().map(|p| p.to_string_lossy().into_owned()),
   |

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/insights_runtime_extractor/process.rs:51:20
   |
51 |     collect_leaves(&root_pid, &mut leaves);
   |                    ^^^^^^^^^ help: change this to: `root_pid`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: length comparison to zero
  --> src/insights_runtime_extractor/process.rs:61:12
   |
61 |         if content.len() == 0 {
   |            ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `content.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#len_zero

error: accessing first element with `leaves.get(0)`
  --> src/insights_runtime_extractor.rs:76:28
   |
76 |     if let Some(process) = leaves.get(0) {
   |                            ^^^^^^^^^^^^^ help: try: `leaves.first()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#get_first

error: function call inside of `expect`
  --> src/insights_runtime_extractor.rs:81:45
   |
81 |           file::create_dir(&container_output).expect(&format!(
   |  _____________________________________________^
82 | |             "Can not create output directory for container {}",
83 | |             &container.id
84 | |         ));
   | |__________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#expect_fun_call
   = note: `-D clippy::expect-fun-call` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::expect_fun_call)]`
help: try
   |
81 ~         file::create_dir(&container_output).unwrap_or_else(|_| panic!("Can not create output directory for container {}",
82 ~             &container.id));
   |

error: called `ok().expect()` on a `Result` value
   --> src/insights_runtime_extractor.rs:100:9
    |
100 | /         fs::copy("/config.toml", container_output.clone() + "/config.toml")
101 | |             .ok()
102 | |             .expect("Copy configuration for fingerprints execution");
    | |____________________________________________________________________^
    |
    = help: you can call `expect()` directly on the `Result`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#ok_expect
    = note: `-D clippy::ok-expect` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ok_expect)]`

error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/insights_runtime_extractor.rs:106:31
    |
106 |         let _ = fork_and_exec(&config, &process, &current_dir, &container_output);
    |                               ^^^^^^^ help: change this to: `config`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/insights_runtime_extractor.rs:106:40
    |
106 |         let _ = fork_and_exec(&config, &process, &current_dir, &container_output);
    |                                        ^^^^^^^^ help: change this to: `process`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: unneeded `return` statement
   --> src/insights_runtime_extractor.rs:133:13
    |
133 |             return Ok(());
    |             ^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_return
help: remove `return`
    |
133 -             return Ok(());
133 +             Ok(())
    |

error: redundant guard
   --> src/insights_runtime_extractor.rs:126:52
    |
126 |                     WaitStatus::Exited(_, code) if code == 0 => {}
    |                                                    ^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#redundant_guards
    = note: `-D clippy::redundant-guards` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_guards)]`
help: try
    |
126 -                     WaitStatus::Exited(_, code) if code == 0 => {}
126 +                     WaitStatus::Exited(_, 0) => {}
    |

error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/insights_runtime_extractor.rs:146:43
    |
146 |             fingerprint::run_fingerprints(&config, out_dir, &process);
    |                                           ^^^^^^^ help: change this to: `config`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/insights_runtime_extractor.rs:146:61
    |
146 |             fingerprint::run_fingerprints(&config, out_dir, &process);
    |                                                             ^^^^^^^^ help: change this to: `process`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrow

error: function call inside of `expect`
   --> src/insights_runtime_extractor.rs:174:33
    |
174 |         let f = File::open(&ns).expect(&format!("Open namespace file {:?}", &ns));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| panic!("Open namespace file {:?}", &ns))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#expect_fun_call

error: function call inside of `expect`
   --> src/insights_runtime_extractor.rs:176:40
    |
176 |         setns(fd, CloneFlags::empty()).expect(&format!("join namespace {:?}", &ns));
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| panic!("join namespace {:?}", &ns))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#expect_fun_call

error: redundant closure
   --> src/insights_runtime_extractor.rs:184:33
    |
184 |     seteuid(uid.into()).map_err(|e| ScannerError::Errno(e))
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the tuple variant itself: `ScannerError::Errno`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#redundant_closure
    = note: `-D clippy::redundant-closure` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure)]`

error: could not compile `insights-runtime-extractor` (lib) due to 43 previous errors
make[1]: *** [Makefile:21: clippy] Error 101
make[1]: Leaving directory '/opt/app-root/src/insights-runtime-extractor/extractor'
make: *** [Makefile:12: check] Error 1
[root@94937286f238 extractor]# 
```


I can create seperate commits to same PR with fix
