### PR TITLE
OCPBUGS:105601: Fix output directories collision.

### DIFF
--- a/extractor/src/bin/coordinator.rs
+++ b/extractor/src/bin/coordinator.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use log::info;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use insights_runtime_extractor::{config, file, get_containers, perms};
+use insights_runtime_extractor::{config, file, file::SCAN_DIR_MODE, get_containers, perms};
 
 #[derive(Parser, Debug)]
 #[command(about, long_about = None)]
@@ -33,10 +33,10 @@ fn main() {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Get Unix timestamp")
-        .subsec_nanos();
+        .as_nanos();
 
     let exec_dir = format!("data/out-{}", timestamp);
-    file::create_dir(exec_dir.as_str()).expect("Can not create execution directory");
+    file::create_dir(exec_dir.as_str(), SCAN_DIR_MODE).expect("Can not create execution directory");
 
     let config = config::get_config("/");
 

--- a/extractor/src/insights_runtime_extractor.rs
+++ b/extractor/src/insights_runtime_extractor.rs
@@ -8,7 +8,7 @@ mod process;
 use log::{debug, error, info, trace, warn};
 use nix::sched::{setns, CloneFlags};
 use nix::sys::wait::{waitpid, WaitStatus};
-use nix::unistd::{fork, seteuid, ForkResult};
+use nix::unistd::{chown, fork, seteuid, ForkResult, Uid};
 use process::ContainerProcess;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -78,9 +78,15 @@ pub fn scan_container(config: &Config, out: &String, container: &Container) {
         // that is put it under a directory from the executing process so that concurrent
         // execution are stored in separate directories.
         let container_output = format!("{}/{}", out, &process.pid);
-        file::create_dir(&container_output).expect(&format!(
+        file::create_dir(&container_output, file::CONTAINER_DIR_MODE).expect(&format!(
             "Can not create output directory for container {}",
             &container.id
+        ));
+        // Hand ownership to the target UID so the child can write after seteuid
+        chown(container_output.as_str(), Some(Uid::from_raw(*process.uid)), None)
+            .expect(&format!(
+                "Can not chown output directory for container {}",
+                &container.id
         ));
 
         let mut container_info = HashMap::new();

--- a/extractor/src/insights_runtime_extractor/file.rs
+++ b/extractor/src/insights_runtime_extractor/file.rs
@@ -5,11 +5,14 @@ use std::io::{self, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
+/// Owner-only access (rwx------) for the top-level scan directory.
+pub const SCAN_DIR_MODE: u32 = 0o700;
+/// Owner + group access (rwxrwx---) for per-container output directories.
+pub const CONTAINER_DIR_MODE: u32 = 0o770;
+
 /// Create a directory and return its File.
 /// Remove the directory if it exists before creating it.
-///
-/// The directory is created with 777 permissions so that anybody can write into it.
-pub fn create_dir(name: &str) -> io::Result<File> {
+pub fn create_dir(name: &str, mode: u32) -> io::Result<File> {
     debug!("📂  (re)creating dir {}", name);
 
     if let Err(e) = fs::remove_dir_all(&name) {
@@ -18,7 +21,7 @@ pub fn create_dir(name: &str) -> io::Result<File> {
         }
     }
     fs::create_dir(name)?;
-    fs::set_permissions(&name, fs::Permissions::from_mode(0o777))?;
+    fs::set_permissions(&name, fs::Permissions::from_mode(mode))?;
 
     File::open(&name)
 }
@@ -82,7 +85,7 @@ mod tests {
     #[test]
     fn it_write_fingerprint() {
         let out = String::from("target/tmp-test");
-        create_dir(&out).expect("Create temporary directory");
+        create_dir(&out, SCAN_DIR_MODE).expect("Create temporary directory");
 
         let mut entries = HashMap::new();
         entries.insert(String::from("foo"), String::from("value1"));


### PR DESCRIPTION
Output directories were created with 0o777 permissions and named using only subsec_nanos (0–999999999), risking collisions when two scans start in the same fractional second.

- Add mode parameter to create_dir with named constants (SCAN_DIR_MODE 0o700, CONTAINER_DIR_MODE 0o770) instead of hardcoded 0o777
- Use as_nanos() (full u128 timestamp) instead of subsec_nanos() for the scan directory name
- chown per-container output dirs to the target UID so the child process can still write after seteuid

JIRA: https://redhat.atlassian.net/browse/OCPBUGS-105601